### PR TITLE
Change Ripgrep to include zips inside the nupkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/*.nupkg
 **/api_key
+*.zip

--- a/packages/ripgrep/legal/LICENSE.txt
+++ b/packages/ripgrep/legal/LICENSE.txt
@@ -1,0 +1,23 @@
+From: https://raw.githubusercontent.com/BurntSushi/ripgrep/master/LICENSE-MIT
+-------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015 Andrew Gallant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/ripgrep/legal/VERIFICATION.txt
+++ b/packages/ripgrep/legal/VERIFICATION.txt
@@ -1,0 +1,20 @@
+VERIFICATION
+
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+Package can be verified like this:
+
+1. Go to
+
+   x32: https://github.com/BurntSushi/ripgrep/releases/download/12.1.1/ripgrep-12.1.1-x86_64-pc-windows-msvc.zip
+   x64: https://github.com/BurntSushi/ripgrep/releases/download/12.1.1/ripgrep-12.1.1-i686-pc-windows-msvc.zip
+
+   to download the zip.
+
+2. You can use one of the following methods to obtain the SHA256 checksum:
+   - Use powershell function 'Get-FileHash'
+   - Use Chocolatey utility 'checksum.exe'
+
+   checksum32: A74D23C8C52A7CFDDAB029E3217CD7AAD49E970AB3EE45FA72FA5F5536230088
+   checksum64: 0256451A21CF5CF88DCD1823FFD2ACD5E89D6B5DC9C2C8AD1324FD0E1F9FF61E

--- a/packages/ripgrep/ripgrep.nuspec
+++ b/packages/ripgrep/ripgrep.nuspec
@@ -33,5 +33,6 @@
   </metadata>
   <files>
     <file src="tools\**" target="tools" />
+    <file src="legal\**" target="legal" />
   </files>
 </package>

--- a/packages/ripgrep/tools/chocolateyinstall.ps1
+++ b/packages/ripgrep/tools/chocolateyinstall.ps1
@@ -1,22 +1,19 @@
 ﻿$ErrorActionPreference = 'Stop';
+$toolsDir               = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$version     = $env:chocolateyPackageVersion
-$packageName = $env:chocolateyPackageName
-$toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-
-$url         = 'https://github.com/BurntSushi/ripgrep/releases/download/12.1.1/ripgrep-12.1.1-x86_64-pc-windows-msvc.zip'
-$url64       = 'https://github.com/BurntSushi/ripgrep/releases/download/12.1.1/ripgrep-12.1.1-i686-pc-windows-msvc.zip'
 
 $packageArgs = @{
-    packageName    = $packageName
-    unzipLocation  = $toolsDir
-    fileType       = 'exe'
-    url            = $url
-    checksum       = 'a74d23c8c52a7cfddab029e3217cd7aad49e970ab3ee45fa72fa5f5536230088'
-    checksumType   = 'sha256'
-    url64bit       = $url64
-    checksum64     = '0256451a21cf5cf88dcd1823ffd2acd5e89d6b5dc9c2c8ad1324fd0e1f9ff61e'
-    checksumType64 = 'sha256'
+    PackageName    = $env:ChocolateyPackageName
+    Destination    = $toolsDir
+    FileFullPath   = Join-Path $toolsDir 'ripgrep-12.1.1-x86_64-pc-windows-msvc.zip'
+    FileFullPath64 = Join-Path $toolsDir 'ripgrep-12.1.1-i686-pc-windows-msvc.zip'
 }
 
-Install-ChocolateyZipPackage @packageArgs
+#Remove old versions of ripgrep in the tools directory
+Get-ChildItem -Directory -Path $toolsDir | Remove-Item -Recurse -Ea 0
+
+Get-ChocolateyUnzip @packageArgs
+
+Write-Host "ripgrep installed to $toolsDir"
+
+Remove-Item -Force -Path $toolsDir\*.zip

--- a/packages/ripgrep/update.ps1
+++ b/packages/ripgrep/update.ps1
@@ -4,16 +4,24 @@ $releases = 'https://github.com/BurntSushi/ripgrep/releases'
 
 function global:au_SearchReplace {
     @{
-        ".\tools\chocolateyinstall.ps1" = @{
-            "(^[$]url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
-            "(^[$]url64\s*=\s*)('.*')" = "`$1'$($Latest.URL64)'"
-            "(?i)(^\s*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
-            "(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
+        ".\tools\chocolateyInstall.ps1" = @{
+            "(?i)(^\s*FileFullPath\s*=\s*)(.*)" = "`$1Join-Path `$toolsDir '$($Latest.FileName32)'"
+            "(?i)(^\s*FileFullPath64\s*=\s*)(.*)" = "`$1Join-Path `$toolsDir '$($Latest.FileName64)'"
+        }
+        ".\legal\VERIFICATION.txt" = @{
+            "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL32)"
+            "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
+            "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
+            "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
         }
         "ripgrep.nuspec" = @{
             "\d+\.\d+\.\d+" = "$($Latest.Version)"
         }
     }
+}
+
+function global:au_BeforeUpdate {
+    Get-RemoteFiles -Purge -NoSuffix
 }
 
 function global:au_GetLatest {
@@ -31,4 +39,4 @@ function global:au_GetLatest {
     }
 }
 
-Update-Package
+Update-Package -ChecksumFor None


### PR DESCRIPTION
Hey @dstcruz 
It is recommended to include the software inside the nupkg instead of downloading it at runtime, assuming that it is allowed by the license and it fits inside the size limit.
The license of Ripgrep allows redistribution, and the total package size is well under the chocolatey.org limit of 200mb.

Tested locally, and AU script updated to match.