### PR TITLE
(#6) Fix update script for ripgrep

### DIFF
--- a/packages/ripgrep/update.ps1
+++ b/packages/ripgrep/update.ps1
@@ -25,7 +25,7 @@ function global:au_BeforeUpdate {
 function global:au_GetLatest {
     $releases = 'https://github.com/BurntSushi/ripgrep/releases/latest'
     $versionRegex = '\/releases\/tag\/(?:v|V)?(?<version>[\d.]+)'
-    Invoke-WebRequest -Uri $releases -UseBasicParsing | Where-Object href -match $versionRegex
+    Invoke-WebRequest -Uri $releases -UseBasicParsing | Select-Object -ExpandProperty Links | Where-Object href -match $versionRegex
     $version = $Matches['version']
     $url_base = "https://github.com/BurntSushi/ripgrep/releases/download/${version}/ripgrep-${version}-"
 


### PR DESCRIPTION
Fixes the `update.ps1` script for ripgrep to extract out the Links.

Fixes #6

How I have tested this:

In Windows PowerShell run `./update.ps1` in the `ripgrep` directory. This now correctly finds the links and downloads them.

Before the change:

![image](https://github.com/dstcruz/chocolatey-mypackages/assets/30301021/c7cd2d34-a604-4d3b-8a78-d55079742593)

After the change:

![image](https://github.com/dstcruz/chocolatey-mypackages/assets/30301021/9014793e-5bc0-49ba-80bd-ab26eda2dd64)
