### PR TITLE
Update ripgrep package for new version

### DIFF
--- a/packages/ripgrep/legal/VERIFICATION.txt
+++ b/packages/ripgrep/legal/VERIFICATION.txt
@@ -7,8 +7,8 @@ Package can be verified like this:
 
 1. Go to
 
-   x32: https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-i686-pc-windows-msvc.zip
-   x64: https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-x86_64-pc-windows-msvc.zip
+   x32: https://github.com/BurntSushi/ripgrep/releases/download/14.1.0/ripgrep-14.1.0-i686-pc-windows-msvc.zip
+   x64: https://github.com/BurntSushi/ripgrep/releases/download/14.1.0/ripgrep-14.1.0-x86_64-pc-windows-msvc.zip
 
    to download the zip.
 
@@ -16,5 +16,5 @@ Package can be verified like this:
    - Use powershell function 'Get-FileHash'
    - Use Chocolatey utility 'checksum.exe'
 
-   checksum32: 75415AA80E2C458A2BB34BDD31653E29EC9B32240141B18D65784B965301EA94
-   checksum64: B6DF202A06CAB342CF28302F319DDD5788DA10672781C38DD49EBE566B423E3F
+   checksum32: 3B2E4776F9510D2F502FEA92F1BE45C02FF0F46DA50F034B04FE866182FFC0D6
+   checksum64: FE4F75EDFAA50F0D4FECBF47696B7629F3449C9C2C5A4DA828753139E5A2E203

--- a/packages/ripgrep/ripgrep.nuspec
+++ b/packages/ripgrep/ripgrep.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>ripgrep</id>
     <title>ripgrep</title>
-    <version>14.0.3</version>
+    <version>14.1.0</version>
     <authors>BurntSushi</authors>
     <owners>Daniel Santa Cruz</owners>
     <summary>A search tool that combines the usability of ag with the raw speed of grep.</summary>
@@ -13,19 +13,19 @@
       with the raw speed of GNU grep. ripgrep has first class support on Windows, Mac and Linux, with binary
       downloads available for every release.
 
-     # Notes on version 14.0.3.20220913
+     # Notes on version 14.1.0.20220913
 
-     After more carefully reviewing the release notes from version 14.0.3, we are now removing the dependency on vcredist2015.
+     After more carefully reviewing the release notes from version 14.1.0, we are now removing the dependency on vcredist2015.
     </description>
-    <releaseNotes>https://github.com/BurntSushi/ripgrep/releases/tag/14.0.3</releaseNotes>
+    <releaseNotes>https://github.com/BurntSushi/ripgrep/releases/tag/14.1.0</releaseNotes>
     <projectUrl>https://github.com/BurntSushi/ripgrep</projectUrl>
     <projectSourceUrl>https://github.com/BurntSushi/ripgrep</projectSourceUrl>
     <bugTrackerUrl>https://github.com/BurntSushi/ripgrep/issues</bugTrackerUrl>
-    <docsUrl>https://github.com/BurntSushi/ripgrep/blob/14.0.3/doc/rg.1.txt.tpl</docsUrl>
+    <docsUrl>https://github.com/BurntSushi/ripgrep/blob/14.1.0/doc/rg.1.txt.tpl</docsUrl>
     <packageSourceUrl>https://github.com/dstcruz/chocolatey-mypackages/tree/master/packages/ripgrep</packageSourceUrl>
     <tags>search ripgrep rg</tags>
     <copyright></copyright>
-    <licenseUrl>https://github.com/BurntSushi/ripgrep/blob/14.0.3/LICENSE-MIT</licenseUrl>
+    <licenseUrl>https://github.com/BurntSushi/ripgrep/blob/14.1.0/LICENSE-MIT</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>
   <files>

--- a/packages/ripgrep/tools/chocolateyinstall.ps1
+++ b/packages/ripgrep/tools/chocolateyinstall.ps1
@@ -5,8 +5,8 @@ $toolsDir               = "$(Split-Path -parent $MyInvocation.MyCommand.Definiti
 $packageArgs = @{
     PackageName    = $env:ChocolateyPackageName
     Destination    = $toolsDir
-    FileFullPath   = Join-Path $toolsDir 'ripgrep-14.0.3-i686-pc-windows-msvc.zip'
-    FileFullPath64 = Join-Path $toolsDir 'ripgrep-14.0.3-x86_64-pc-windows-msvc.zip'
+    FileFullPath   = Join-Path $toolsDir 'ripgrep-14.1.0-i686-pc-windows-msvc.zip'
+    FileFullPath64 = Join-Path $toolsDir 'ripgrep-14.1.0-x86_64-pc-windows-msvc.zip'
 }
 
 #Remove old versions of ripgrep in the tools directory


### PR DESCRIPTION
Ripgrep updated to another version. I've run the update script and pushed to Chocolatey Community Repository. This PR keeps the repository in line with the package version.

![image](https://github.com/dstcruz/chocolatey-mypackages/assets/30301021/cdfcf79c-7be7-4ede-8f0f-523a3d99c4bb)
